### PR TITLE
Misc patches for review

### DIFF
--- a/sys/arm/arm/gic.c
+++ b/sys/arm/arm/gic.c
@@ -165,7 +165,6 @@ arm_gic_probe(device_t dev)
 	return (BUS_PROBE_DEFAULT);
 }
 
-#if 0
 static void
 arm_gic_init_secondary(device_t dev)
 {
@@ -241,7 +240,6 @@ gic_decode_fdt(uint32_t iparent, uint32_t *intr, int *interrupt,
 	}
 	return (0);
 }
-#endif
 
 static int
 arm_gic_attach(device_t dev)
@@ -364,7 +362,6 @@ gic_eoi(device_t dev, u_int irq)
 	gic_c_write_4(sc, GICC_EOIR, irq);
 }
 
-#if 0
 static int
 arm_gic_next_irq(struct arm_gic_softc *sc, int last_irq)
 {
@@ -389,7 +386,6 @@ arm_gic_next_irq(struct arm_gic_softc *sc, int last_irq)
 
 	return active_irq;
 }
-#endif
 
 void
 gic_mask_irq(device_t dev, u_int irq)
@@ -413,7 +409,6 @@ gic_unmask_irq(device_t dev, u_int irq)
 	gic_d_write_4(sc, GICD_ISENABLER(irq >> 5), (1UL << (irq & 0x1F)));
 }
 
-#if 0
 static int
 arm_gic_config(device_t dev, int irq, enum intr_trigger trig,
     enum intr_polarity pol)
@@ -481,12 +476,13 @@ arm_gic_unmask(device_t dev, int irq)
 {
 	struct arm_gic_softc *sc = device_get_softc(dev);
 
+	/* TODO: Get working on arm64 */
+#if 0
 	if (irq > GIC_LAST_IPI)
 		arm_irq_memory_barrier(irq);
-
+#endif
 	gic_d_write_4(sc, GICD_ISENABLER(irq >> 5), (1UL << (irq & 0x1F)));
 }
-#endif
 
 #ifdef SMP
 static void
@@ -526,15 +522,18 @@ arm_gic_ipi_clear(device_t dev, int ipi)
 }
 #endif
 
-#if 0
 static void
 gic_post_filter(void *arg)
 {
 	struct arm_gic_softc *sc = arm_gic_sc;
 	uintptr_t irq = (uintptr_t) arg;
 
+	/* TODO: Get working on arm64 */
+#if 0
 	if (irq > GIC_LAST_IPI)
 		arm_irq_memory_barrier(irq);
+#endif
+
 	gic_c_write_4(sc, GICC_EOIR, irq);
 }
 
@@ -594,7 +593,6 @@ pic_ipi_clear(int ipi)
 
 	arm_gic_ipi_clear(arm_gic_sc->gic_dev, ipi);
 }
-#endif
 #endif
 
 static device_method_t arm_gic_methods[] = {

--- a/sys/arm64/arm64/cpufunc.c
+++ b/sys/arm64/arm64/cpufunc.c
@@ -1,0 +1,217 @@
+/*-
+ * Copyright (c) 2014 Robin Randhawa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/*
+ * This cpufuncs implementation is based on the ARM v7 implementation.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/bus.h>
+#include <machine/bus.h>
+#include <machine/cpu.h>
+
+#include <vm/vm.h>
+#include <vm/pmap.h>
+#include <vm/uma.h>
+
+#include <machine/cpufunc.h>
+
+/* PRIMARY CACHE VARIABLES */
+int	arm64_picache_size;
+int	arm64_picache_line_size;
+int	arm64_picache_ways;
+
+int	arm64_pdcache_size;	/* and unified */
+int	arm64_pdcache_line_size;
+int	arm64_pdcache_ways;
+
+int	arm64_pcache_type;
+int	arm64_pcache_unified;
+
+int	arm64_dcache_align;
+int	arm64_dcache_align_mask;
+
+u_int	arm64_cache_level;
+u_int	arm64_cache_type[14];
+u_int	arm64_cache_loc;
+
+/* 1 == use cpu_sleep(), 0 == don't */
+int cpu_do_powersave;
+int ctrl;
+
+struct cpu_functions arm64_cpufuncs = {
+	/* CPU functions */
+	
+	arm64_id,                     /* id                   */
+	arm64_nullop,                 /* cpwait               */
+	
+	/* MMU functions */
+	
+	arm64_control,                /* control              */
+	arm64_setttb,                 /* Setttb               */
+	arm64_faultstatus,            /* Faultstatus          */
+	arm64_faultaddress,           /* Faultaddress         */
+	
+	/* 
+	 * TLB functions.  ARMv7 does all TLB ops based on a unified TLB model
+	 * whether the hardware implements separate I+D or not, so we use the
+	 * same 'ID' functions for all 3 variations.
+	 */
+	
+	arm64_tlb_flushID,              /* tlb_flushID          */
+	arm64_tlb_flushID_SE,           /* tlb_flushID_SE       */
+	arm64_tlb_flushID,              /* tlb_flushI           */
+	arm64_tlb_flushID_SE,           /* tlb_flushI_SE        */
+	arm64_tlb_flushID,              /* tlb_flushD           */
+	arm64_tlb_flushID_SE,           /* tlb_flushD_SE        */
+	
+	/* Cache operations */
+	
+	arm64_icache_sync_range,        /* icache_sync_range    */
+	
+	arm64_dcache_wbinv_range,       /* dcache_wbinv_range   */
+	arm64_dcache_inv_range,         /* dcache_inv_range     */
+	arm64_dcache_wb_range,          /* dcache_wb_range      */
+	
+	arm64_idcache_wbinv_range,      /* idcache_wbinv_range  */
+	
+	/* 
+	 * Note: For CPUs using the PL310 the L2 ops are filled in when the
+	 * L2 cache controller is actually enabled.
+	 */
+	(void *)arm64_nullop,         /* l2cache_wbinv_range  */
+	(void *)arm64_nullop,         /* l2cache_inv_range    */
+	(void *)arm64_nullop,         /* l2cache_wb_range     */
+	(void *)arm64_nullop,         /* l2cache_drain_writebuf */
+	
+	/* Other functions */
+	
+	arm64_nullop,                 /* flush_prefetchbuf    */
+	arm64_drain_writebuf,           /* drain_writebuf       */
+	arm64_nullop,                 /* flush_brnchtgt_C     */
+	(void *)arm64_nullop,         /* flush_brnchtgt_E     */
+	
+	arm64_sleep,                    /* sleep                */
+	
+	/* Soft functions */
+	
+	arm64_null_fixup,             /* dataabt_fixup        */
+	arm64_null_fixup,             /* prefetchabt_fixup    */
+	
+	arm64_context_switch,           /* context_switch       */
+	
+	arm64_setup                     /* cpu setup            */
+};
+
+/*
+ * Global constants also used by locore.s
+ */
+
+struct cpu_functions cpufuncs;
+u_int cputype;
+
+static void get_cachetype(void);
+
+/* Additional cache information local to this file.  Log2 of some of the
+   above numbers.  */
+static int	arm64_dcache_l2_nsets;
+static int	arm64_dcache_l2_assoc;
+static int	arm64_dcache_l2_linesize;
+
+static void
+get_cachetype()
+{
+	arm64_dcache_l2_nsets = 0;
+	arm64_dcache_l2_assoc = 0;
+	arm64_dcache_l2_linesize = 0;
+}
+
+/*
+ * Cannot panic here as we may not have a console yet ...
+ */
+
+int
+set_cpufuncs()
+{
+
+	/*
+	 * NOTE: cpu_do_powersave defaults to off.  If we encounter a
+	 * CPU type where we want to use it by default, then we set it.
+	 */
+
+	cpufuncs = arm64_cpufuncs;
+	get_cachetype();
+
+	/* Use powersave on this CPU. */
+	cpu_do_powersave = 1;
+
+	uma_set_align(arm64_dcache_align_mask);
+	return (0);
+}
+
+/*
+ * Fixup routines for data and prefetch aborts.
+ *
+ * Several compile time symbols are used
+ *
+ * DEBUG_FAULT_CORRECTION - Print debugging information during the
+ * correction of registers after a fault.
+ */
+
+/*
+ * Null abort fixup routine.
+ * For use when no fixup is required.
+ */
+int
+arm64_null_fixup(arg)
+	void *arg;
+{
+	return(ABORT_FIXUP_OK);
+}
+
+/*
+ * CPU Setup code
+ */
+void
+arm64_setup(char *args)
+{
+
+	uint32_t linesz;
+
+	/*
+	 * Record I and D minimum line sizes - may need this sooner.
+	 */
+	__asm __volatile("mrs	%0, ctr_el0\n" : "=r" (linesz) : );
+	arm64_pdcache_line_size = (linesz & 0xF) >> 16;
+	arm64_picache_line_size = (linesz & 0xF);
+}

--- a/sys/arm64/arm64/cpufunc_asm.S
+++ b/sys/arm64/arm64/cpufunc_asm.S
@@ -1,0 +1,235 @@
+/*-
+ * Copyright (c) 2014 Robin Randhawa 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <machine/asm.h>
+#include <machine/param.h>
+__FBSDID("$FreeBSD$");
+
+/*
+ * FIXME: 
+ * Need big.LITTLE awareness at some point.
+ * Using arm64_p[id]cache_line_size may not be the best option.
+ * Need better SMP awareness.
+ */
+	.text
+	.align	2
+
+.Lpage_mask:
+	.word	PAGE_MASK
+
+ENTRY(arm64_nullop)
+	ret
+END(arm64_nullop)
+
+ENTRY(arm64_id)
+	mrs	x0, midr_el1
+	ret
+END(arm64_id)
+
+ENTRY(arm64_cpuid)
+	mrs	x0, mpidr_el1
+	ret
+END(arm64_cpuid)
+
+ENTRY(arm64_faultstatus)
+	mrs	x0, esr_el1
+	ret
+END(arm64_faultstatus)
+
+ENTRY(arm64_faultaddress)
+	mrs	x0, far_el1
+	ret
+END(arm64_faultaddress)
+
+/*
+ * Generic functions to read/modify/write the internal coprocessor registers
+ */
+
+ENTRY(arm64_control)
+	mrs	x3, sctlr_el1
+	bic	x2, x3, x0
+	eor	x2, x2, x1
+
+	cmp	x2, x3
+	b.eq	1f
+	msr	sctlr_el1, x2
+1:
+	mov	x0, x3
+	ret
+END(arm64_control)
+
+ENTRY(arm64_setttb)
+	dsb	ish
+	msr	ttbr0_el1, x0
+	dsb	ish
+	isb
+	ret
+END(arm64_setttb)
+
+ENTRY(arm64_tlb_flushID)
+#ifdef SMP
+	tlbi	vmalle1is
+#else
+	tlbi	vmalle1
+#endif
+	dsb	ish
+	isb
+	ret
+END(arm64_tlb_flushID)
+
+ENTRY(arm64_tlb_flushID_SE)
+	ldr	x1, .Lpage_mask
+	bic	x0, x0, x1
+#ifdef SMP
+	tlbi	vae1is, x0
+#else
+	tlbi	vae1, x0
+#endif
+	dsb	ish
+	isb
+	ret
+END(arm64_tlb_flushID_SE)
+
+ENTRY(arm64_dcache_wb_range)
+	ldr	x3, =arm64_pdcache_line_size
+	sub	x3, x3, #1
+	and	x2, x0, x3
+	add	x1, x1, x2
+	bic	x0, x0, x3
+.Larm64_dcwb_next:
+	dc	cvac, x0
+	add	x0, x0, x3
+	subs	x1, x1, x3
+	b.hi	.Larm64_dcwb_next
+	dsb	ish
+	ret
+END(arm64_dcache_wb_range)
+
+ENTRY(arm64_dcache_wbinv_range)
+	ldr	x3, =arm64_pdcache_line_size
+	sub	x3, x3, #1
+	and	x2, x0, x3
+	add	x1, x1, x2
+	bic	x0, x0, x3
+.Larm64_dcwbi_next:
+	dc	civac, x0
+	add	x0, x0, x3
+	subs	x1, x1, x3
+	b.hi	.Larm64_dcwbi_next
+	dsb	ish
+	ret
+END(arm64_dcache_wbinv_range)
+
+/*
+ * Note, we must not invalidate everything.  If the range is too big we
+ * must use wb-inv of the entire cache.
+ */
+ENTRY(arm64_dcache_inv_range)
+	ldr	x3, =arm64_pdcache_line_size
+	sub	x3, x3, #1
+	and	x2, x0, x3
+	add	x1, x1, x2
+	bic	x0, x0, x3
+.Larm64_dci_next:
+	dc	ivac, x0
+	add	x0, x0, x3
+	subs	x1, x1, x3
+	b.hi	.Larm64_dci_next
+	dsb	ish
+	ret
+END(arm64_dcache_inv_range)
+
+ENTRY(arm64_idcache_wbinv_range)
+	ldr	x3, =arm64_pdcache_line_size
+	sub	x3, x3, #1
+	and	x2, x0, x3
+	add	x1, x1, x2
+	bic	x0, x0, x3
+.Larm64_idcwbi_next:
+	ic	ivau, x0
+	dc	civac, x0
+	add	x0, x0, x3
+	subs	x1, x1, x3
+	b.hi	.Larm64_idcwbi_next
+	isb
+	dsb	ish
+	ret
+END(arm64_idcache_wbinv_range)
+
+ENTRY(arm64_icache_sync_range)
+	ldr	x3, =arm64_pdcache_line_size
+.Larm64_sync_next:
+	ic	ivau,	x0
+	dc	cvac,	x0
+	add	x0, x0, x3
+	subs	x1, x1, x3
+	bhi	.Larm64_sync_next
+	isb
+	dsb	ish
+	ret
+END(arm64_icache_sync_range)
+
+ENTRY(arm64_cpu_sleep)
+	dsb	ish
+	wfi
+	ret
+END(arm64_cpu_sleep)
+
+ENTRY(arm64_context_switch)
+	dsb	ish
+
+	msr	ttbr0_el1, x0
+	isb
+#ifdef SMP
+	tlbi	alle1is
+#else
+	tlbi	alle1
+#endif
+	dsb	ish
+	isb
+	ret
+END(arm64_context_switch)
+
+ENTRY(arm64_drain_writebuf)
+	dsb	ish
+	ret
+END(arm64_drain_writebuf)
+
+ENTRY(arm64_sev)
+	dsb	ish
+	sev
+	nop
+	ret
+END(arm64_sev)
+
+ENTRY(arm64_auxctrl)
+	ret
+END(arm64_auxctrl)
+
+ENTRY(arm64_sleep)
+	ret
+END(arm64_sleep)

--- a/sys/arm64/arm64/genassym.c
+++ b/sys/arm64/arm64/genassym.c
@@ -50,6 +50,13 @@ ASSYM(PCB_SP, offsetof(struct pcb, pcb_sp));
 ASSYM(PCB_L1ADDR, offsetof(struct pcb, pcb_l1addr));
 ASSYM(PCB_ONFAULT, offsetof(struct pcb, pcb_onfault));
 
+ASSYM(CF_SETTTB, offsetof(struct cpu_functions, cf_setttb));
+ASSYM(CF_CONTROL, offsetof(struct cpu_functions, cf_control));
+ASSYM(CF_CONTEXT_SWITCH, offsetof(struct cpu_functions, cf_context_switch));
+ASSYM(CF_DCACHE_WB_RANGE, offsetof(struct cpu_functions, cf_dcache_wb_range));
+ASSYM(CF_L2CACHE_WB_RANGE, offsetof(struct cpu_functions, cf_l2cache_wb_range));
+ASSYM(CF_TLB_FLUSHID_SE, offsetof(struct cpu_functions, cf_tlb_flushID_SE));
+
 ASSYM(SF_UC, offsetof(struct sigframe, sf_uc));
 
 ASSYM(TD_PCB, offsetof(struct thread, td_pcb));

--- a/sys/arm64/arm64/genassym.c
+++ b/sys/arm64/arm64/genassym.c
@@ -56,4 +56,7 @@ ASSYM(TD_PCB, offsetof(struct thread, td_pcb));
 ASSYM(TD_FLAGS, offsetof(struct thread, td_flags));
 ASSYM(TD_LOCK, offsetof(struct thread, td_lock));
 
+ASSYM(PC_CPU, offsetof(struct pcpu, pc_cpu));
+ASSYM(PC_CURPMAP, offsetof(struct pcpu, pc_curpmap));
+
 ASSYM(TF_X, offsetof(struct trapframe, tf_x));

--- a/sys/arm64/arm64/identcpu.c
+++ b/sys/arm64/arm64/identcpu.c
@@ -70,8 +70,9 @@ uint64_t __cpu_affinity[MAXCPU];
 #define	CPU_IMPL_INTEL		0x69
 
 #define	CPU_PART_THUNDER	0x0A1
-#define	CPU_PART_CORTEX_A57	0xD00
+#define	CPU_PART_FOUNDATION	0xD00
 #define	CPU_PART_CORTEX_A53	0xD03
+#define	CPU_PART_CORTEX_A57	0xD07
 
 #define	CPU_IMPL(midr)	(((midr) >> 24) & 0xff)
 #define	CPU_PART(midr)	(((midr) >> 4) & 0xfff)
@@ -111,8 +112,9 @@ struct cpu_implementers {
  */
 /* ARM Ltd. */
 static const struct cpu_parts cpu_parts_arm[] = {
-	{ 0xD00, "Cortex-A57" },
+	{ 0xD00, "Foundation-Model" },
 	{ 0xD03, "Cortex-A53" },
+	{ 0xD07, "Cortex-A57" },
 	CPU_PART_NONE,
 };
 /* Cavium */

--- a/sys/arm64/arm64/locore.S
+++ b/sys/arm64/arm64/locore.S
@@ -38,6 +38,10 @@
 
 #define	VIRT_BITS	39
 
+#define MPIDR_AFF_BITS	    8
+#define MPIDR_CPU_MSK	    0xff
+#define MPIDR_CLUSTER_MSK   (MPIDR_CPU_MSK << MPIDR_AFF_BITS)
+
 	.globl	kernbase
 	.set	kernbase, KERNBASE
 
@@ -53,9 +57,20 @@
 
 	.text
 	.globl _start
+	.globl mpentry
 _start:
+mpentry:
 	/* Drop to EL1 */
 	bl	drop_to_el1
+
+	/*
+	 * Get the current CPU index. Assumes 4 CPUs/Cluster. Uses x16.
+	 */
+	mrs	x16, mpidr_el1
+
+	and	x17, x16, #MPIDR_CPU_MSK
+	ubfx	x16, x16, #(MPIDR_AFF_BITS), #(MPIDR_AFF_BITS)
+	add	x16, x17, x16, LSL #2
 
 	/* Get the virt -> phys offset */
 	bl	get_virt_delta
@@ -66,7 +81,12 @@ _start:
 	 * x28 = Our physical load address
 	 */
 
-	/* Create the page tables */
+	/*
+	 * Create the page tables - only if we're the primary CPU
+	 */
+	cmp	x16, #0
+	b.hi	1f
+
 	bl	create_pagetables
 
 	/*
@@ -74,7 +94,20 @@ _start:
 	 * x27 = TTBR0 table
 	 * x26 = TTBR1 table
 	 */
+	adr	x15, .Lttbr0
+	str	x27, [x15]
 
+	adr	x15, .Lttbr1
+	str	x26, [x15]
+
+	b	2f
+1:
+	adr	x15, .Lttbr0
+	ldr	x27, [x15]
+
+	adr	x15, .Lttbr1
+	ldr	x26, [x15]
+2:
 	/* Enable the mmu */
 	bl	start_mmu
 
@@ -84,16 +117,27 @@ _start:
 
 virtdone:
 	/* Set up the stack */
-	adr	x25, initstack_end
+	adr	x25, initstack
+
+	mov	x15,  #(PAGE_SIZE * KSTACK_PAGES)
+	madd	x25, x16, x15, x25
+	add	x25, x25, #(PAGE_SIZE * KSTACK_PAGES)
+
 	mov	sp, x25
+
+	/*
+	 * Secondaries jump ahead to init_secondary.
+	 */
+	cmp	x16, #0
+	b.hi	4f
 
 	/* Zero the BSS */
 	ldr	x15, .Lbss
 	ldr	x14, .Lend
-1:
+3:
 	str	xzr, [x15], #8
 	cmp	x15, x14
-	b.lo	1b
+	b.lo	3b
 
 	/* Backup the module pointer */
 	mov	x1, x0
@@ -112,10 +156,19 @@ virtdone:
 	str	x29, [x0, 16]	/* kern_delta */
 	str	x25, [x0, 24]	/* kern_stack */
 
-	/* Branch to C code */
+	/*
+	 * Branch to C code.
+	 */
 	bl	initarm
 	bl	mi_startup
+	b	5f
+4:
+	mov	x0, x16
+#ifdef SMP
+	bl	init_secondary
+#endif
 
+5:
 	/* We should not get here */
 	brk	0
 
@@ -126,6 +179,10 @@ virtdone:
 	.quad	__bss_start
 .Lend:
 	.quad	_end
+.Lttbr0:
+	.space	8
+.Lttbr1:
+	.space	8
 
 /*
  * If we are started in EL2, configure the required hypervisor
@@ -500,7 +557,7 @@ init_pt_va:
 
 	.align	4
 initstack:
-	.space	(PAGE_SIZE * KSTACK_PAGES)
+	.space	(PAGE_SIZE * KSTACK_PAGES * MAXCPU)
 initstack_end:
 
 

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -95,6 +95,7 @@ long realmem = 0;
 #define	PHYSMAP_SIZE	(2 * (VM_PHYSSEG_MAX - 1))
 vm_paddr_t physmap[PHYSMAP_SIZE];
 u_int physmap_idx;
+vm_paddr_t pmap_pa;
 
 struct kva_md_info kmi;
 
@@ -310,6 +311,13 @@ cpu_idle(int busy)
 	if (!busy)
 		cpu_activeclock();
 	spinlock_exit();
+}
+
+int
+cpu_idle_wakeup(int cpu)
+{
+
+	return (0);
 }
 
 void
@@ -763,6 +771,9 @@ initarm(struct arm64_bootparams *abp)
 	set_curthread(&thread0);
 	pcpu_init(pcpup, 0, sizeof(struct pcpu));
 	PCPU_SET(curthread, &thread0);
+
+	/* Needed for secondary init. */
+	pmap_pa = abp->kern_l1pt;
 
 	/* Do basic tuning, hz etc */
 	init_param1();

--- a/sys/arm64/arm64/machdep.c
+++ b/sys/arm64/arm64/machdep.c
@@ -735,6 +735,8 @@ initarm(struct arm64_bootparams *abp)
 
 	printf("In initarm on arm64\n");
 
+	set_cpufuncs();
+
 	/* Set the module data location */
 	preload_metadata = (caddr_t)(uintptr_t)(abp->modulep);
 

--- a/sys/arm64/arm64/mp_machdep.c
+++ b/sys/arm64/arm64/mp_machdep.c
@@ -1,0 +1,471 @@
+/*-
+ * Copyright (c) Robin Randhawa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * This work is based on the ARM v7 version by Semihalf.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+#include <sys/proc.h>
+#include <sys/pcpu.h>
+#include <sys/sched.h>
+#include <sys/smp.h>
+#include <sys/ktr.h>
+#include <sys/malloc.h>
+
+#include <vm/vm.h>
+#include <vm/vm_extern.h>
+#include <vm/vm_kern.h>
+#include <vm/pmap.h>
+
+#include <machine/armreg.h>
+#include <machine/cpu.h>
+#include <machine/cpufunc.h>
+#include <machine/smp.h>
+#include <machine/pcb.h>
+#include <machine/psci.h>
+#include <machine/pte.h>
+#include <machine/intr.h>
+#include <machine/vmparam.h>
+#ifdef VFP
+#include <machine/vfp.h>
+#endif
+
+#include "opt_smp.h"
+
+extern struct pcpu __pcpu[];
+/* used to hold the AP's until we are ready to release them */
+struct mtx ap_boot_mtx;
+struct pcb stoppcbs[MAXCPU];
+
+/* # of Applications processors */
+volatile int mp_naps;
+
+/* Set to 1 once we're ready to let the APs out of the pen. */
+volatile int aps_ready = 0;
+
+static int ipi_handler(void *arg);
+void set_stackptrs(int cpu);
+
+/* Temporary variables for init_secondary()  */
+void *dpcpu[MAXCPU - 1];
+
+/* Determine if we running MP machine */
+int
+cpu_mp_probe(void)
+{
+	CPU_SETOF(0, &all_cpus);
+
+	return (platform_mp_probe());
+}
+
+/* Start Application Processor via platform specific function */
+static int
+check_ap(void)
+{
+	uint32_t ms;
+
+	for (ms = 0; ms < 2000; ++ms) {
+		if ((mp_naps + 1) == mp_ncpus)
+			return (0);		/* success */
+		else
+			DELAY(1000);
+	}
+
+	return (-2);
+}
+
+extern unsigned char _end[];
+
+/* Initialize and fire up non-boot processors */
+void
+cpu_mp_start(void)
+{
+	int error, i;
+
+	mtx_init(&ap_boot_mtx, "ap boot", NULL, MTX_SPIN);
+
+	/* Reserve memory for application processors */
+	for(i = 0; i < (mp_ncpus - 1); i++)
+		dpcpu[i] = (void *)kmem_malloc(kernel_arena, DPCPU_SIZE,
+		    M_WAITOK | M_ZERO);
+
+	/* Initialize boot code and start up processors */
+	platform_mp_start_ap();
+
+	/*  Check if ap's started properly */
+	error = check_ap();
+	if (error)
+		printf("WARNING: Some AP's failed to start\n");
+	else
+		for (i = 1; i < mp_ncpus; i++)
+			CPU_SET(i, &all_cpus);
+}
+
+/* Introduce rest of cores to the world */
+void
+cpu_mp_announce(void)
+{
+
+}
+
+extern vm_paddr_t pmap_pa;
+
+void
+init_secondary(int cpu)
+{
+	struct pcpu *pc;
+	uint32_t loop_counter;
+	int start = 0, end = 0;
+
+	printf("%s: called...\n", __FUNCTION__);
+	cpu_setup(NULL);
+	printf("%s: pmap_pa = 0x%016llx\n", __FUNCTION__, (unsigned long long)pmap_pa);
+	setttb(pmap_pa);
+	cpu_tlb_flushID();
+
+	pc = &__pcpu[cpu];
+
+	/*
+	 * pcpu_init() updates queue, so it should not be executed in parallel
+	 * on several cores
+	 */
+	while(mp_naps < (cpu - 1))
+		;
+
+	pcpu_init(pc, cpu, sizeof(struct pcpu));
+	dpcpu_init(dpcpu[cpu - 1], cpu);
+
+	/* Provide stack pointers for other processor modes. */
+#if 0
+	set_stackptrs(cpu);
+#endif
+
+	/* Signal our startup to BSP */
+	atomic_add_rel_32(&mp_naps, 1);
+
+	/* Spin until the BSP releases the APs */
+	while (!aps_ready)
+		__asm __volatile("hint #1");
+
+	/* Initialize curthread */
+	KASSERT(PCPU_GET(idlethread) != NULL, ("no idle thread"));
+	pc->pc_curthread = pc->pc_idlethread;
+	pc->pc_curpcb = pc->pc_idlethread->td_pcb;
+	set_curthread(pc->pc_idlethread);
+#ifdef VFP
+	pc->pc_cpu = cpu;
+
+	vfp_init();
+#endif
+
+	mtx_lock_spin(&ap_boot_mtx);
+
+	atomic_add_rel_32(&smp_cpus, 1);
+
+	if (smp_cpus == mp_ncpus) {
+		/* enable IPI's, tlb shootdown, freezes etc */
+		atomic_store_rel_int(&smp_started, 1);
+	}
+
+	mtx_unlock_spin(&ap_boot_mtx);
+
+	/* Enable ipi */
+#ifdef IPI_IRQ_START
+	start = IPI_IRQ_START;
+#ifdef IPI_IRQ_END
+  	end = IPI_IRQ_END;
+#else
+	end = IPI_IRQ_START;
+#endif
+#endif
+				
+	for (int i = start; i <= end; i++)
+		arm_unmask_irq(i);
+	intr_enable();
+
+	loop_counter = 0;
+	while (smp_started == 0) {
+		DELAY(100);
+		loop_counter++;
+		if (loop_counter == 1000)
+			CTR0(KTR_SMP, "AP still wait for smp_started");
+	}
+	/* Start per-CPU event timers. */
+	cpu_initclocks_ap();
+
+	CTR0(KTR_SMP, "go into scheduler");
+	platform_mp_init_secondary();
+
+	/* Enter the scheduler */
+	sched_throw(NULL);
+
+	panic("scheduler returned us to %s", __func__);
+	/* NOTREACHED */
+}
+
+static int
+ipi_handler(void *arg)
+{
+	u_int	cpu, ipi;
+
+	cpu = PCPU_GET(cpuid);
+
+	ipi = pic_ipi_read((int)arg);
+
+	while ((ipi != 0x3ff)) {
+		switch (ipi) {
+		case IPI_RENDEZVOUS:
+			CTR0(KTR_SMP, "IPI_RENDEZVOUS");
+			smp_rendezvous_action();
+			break;
+
+		case IPI_AST:
+			CTR0(KTR_SMP, "IPI_AST");
+			break;
+
+		case IPI_STOP:
+			/*
+			 * IPI_STOP_HARD is mapped to IPI_STOP so it is not
+			 * necessary to add it in the switch.
+			 */
+			CTR0(KTR_SMP, "IPI_STOP or IPI_STOP_HARD");
+
+			savectx(&stoppcbs[cpu]);
+
+			/*
+			 * CPUs are stopped when entering the debugger and at
+			 * system shutdown, both events which can precede a
+			 * panic dump.  For the dump to be correct, all caches
+			 * must be flushed and invalidated, but on ARM there's
+			 * no way to broadcast a wbinv_all to other cores.
+			 * Instead, we have each core do the local wbinv_all as
+			 * part of stopping the core.  The core requesting the
+			 * stop will do the l2 cache flush after all other cores
+			 * have done their l1 flushes and stopped.
+			 */
+#if 0
+			cpu_idcache_wbinv_all();
+#endif
+
+			/* Indicate we are stopped */
+			CPU_SET_ATOMIC(cpu, &stopped_cpus);
+
+			/* Wait for restart */
+			while (!CPU_ISSET(cpu, &started_cpus))
+				cpu_spinwait();
+
+			CPU_CLR_ATOMIC(cpu, &started_cpus);
+			CPU_CLR_ATOMIC(cpu, &stopped_cpus);
+			CTR0(KTR_SMP, "IPI_STOP (restart)");
+			break;
+		case IPI_PREEMPT:
+			CTR1(KTR_SMP, "%s: IPI_PREEMPT", __func__);
+			sched_preempt(curthread);
+			break;
+		case IPI_HARDCLOCK:
+			CTR1(KTR_SMP, "%s: IPI_HARDCLOCK", __func__);
+			hardclockintr();
+			break;
+		case IPI_TLB:
+			CTR1(KTR_SMP, "%s: IPI_TLB", __func__);
+			cpufuncs.cf_tlb_flushID();
+			break;
+		default:
+			panic("Unknown IPI 0x%0x on cpu %d", ipi, curcpu);
+		}
+
+		pic_ipi_clear(ipi);
+		ipi = pic_ipi_read(-1);
+	}
+
+	return (FILTER_HANDLED);
+}
+
+static void
+release_aps(void *dummy __unused)
+{
+	uint32_t loop_counter;
+	int start = 0, end = 0;
+	int ret;
+
+	printf("%s: called ..\n", __FUNCTION__);
+	if (mp_ncpus == 1)
+		return;
+#ifdef IPI_IRQ_START
+	start = IPI_IRQ_START;
+#ifdef IPI_IRQ_END
+	end = IPI_IRQ_END;
+#else
+	end = IPI_IRQ_START;
+#endif
+#endif
+
+	for (int i = start; i <= end; i++) {
+		/*
+		 * IPI handler
+		 */
+		/* 
+		 * Use 0xdeadbeef as the argument value for irq 0,
+		 * if we used 0, the intr code will give the trap frame
+		 * pointer instead.
+		 */
+		ret = arm_setup_intr("ipi", ipi_handler, NULL, (void *)(uintptr_t)i, i,
+		    INTR_TYPE_MISC | INTR_EXCL, NULL);
+
+		/* Enable ipi */
+		arm_unmask_irq(i);
+	}
+	atomic_store_rel_int(&aps_ready, 1);
+
+	printf("Release APs\n");
+
+	for (loop_counter = 0; loop_counter < 2000; loop_counter++) {
+		if (smp_started)
+			return;
+		DELAY(1000);
+	}
+	printf("AP's not started\n");
+}
+
+SYSINIT(start_aps, SI_SUB_SMP, SI_ORDER_FIRST, release_aps, NULL);
+
+struct cpu_group *
+cpu_topo(void)
+{
+
+	return (smp_topo_1level(CG_SHARE_L2, mp_ncpus, 0));
+}
+
+void
+cpu_mp_setmaxid(void)
+{
+
+	platform_mp_setmaxid();
+}
+
+/* Sending IPI */
+void
+ipi_all_but_self(u_int ipi)
+{
+	cpuset_t other_cpus;
+
+	other_cpus = all_cpus;
+	CPU_CLR(PCPU_GET(cpuid), &other_cpus);
+	CTR2(KTR_SMP, "%s: ipi: %x", __func__, ipi);
+	platform_ipi_send(other_cpus, ipi);
+}
+
+void
+ipi_cpu(int cpu, u_int ipi)
+{
+	cpuset_t cpus;
+
+	CPU_ZERO(&cpus);
+	CPU_SET(cpu, &cpus);
+
+	CTR3(KTR_SMP, "%s: cpu: %d, ipi: %x", __func__, cpu, ipi);
+	platform_ipi_send(cpus, ipi);
+}
+
+void
+ipi_selected(cpuset_t cpus, u_int ipi)
+{
+
+	CTR2(KTR_SMP, "%s: ipi: %x", __func__, ipi);
+	platform_ipi_send(cpus, ipi);
+}
+
+void
+tlb_broadcast(int ipi)
+{
+
+	if (smp_started)
+		ipi_all_but_self(ipi);
+}
+
+void
+platform_mp_init_secondary(void)
+{
+	arm_init_secondary_ic();
+}
+
+void
+platform_mp_setmaxid(void)
+{
+
+	mp_ncpus = 2;
+        mp_maxid = mp_ncpus - 1;
+}
+
+int
+platform_mp_probe(void)
+{
+
+#if 1
+	return (mp_ncpus > 1);
+#else
+	return (0);
+#endif
+}
+
+void    
+platform_mp_start_ap(void)
+{
+	uint64_t fn, entry, contextid;
+	int i;
+
+	fn = PSCI_FNID_CPU_ON;
+	entry = (uint64_t)pmap_kextract((vm_offset_t)mpentry);
+	contextid = 0;
+
+	/*
+	 * FIXME: I can't call psci_cpu_on yet since the PSCI driver hasn't been
+	 * initialised. How do I fix this ? EARLY_DRIVER_MODULE with
+	 * BUS_PASS_CPU and BUS_PASS_ORDER_FIRST didn't help.
+	 *
+	 * One option would be to call psci_{hvc/smc}_despatch() directly but
+	 * the problem then is that I don't know which one to call because I
+	 * can't check for FDT properties at this point either.
+	 *
+	 * Assuming psci_hvc_despatch at the moment [massive hack].
+	 */
+	for (i = 1; i < mp_ncpus; i++) 
+		psci_hvc_despatch(fn, i, entry, contextid);
+}
+
+void
+platform_ipi_send(cpuset_t cpus, u_int ipi)
+{
+	pic_ipi_send(cpus, ipi);
+}

--- a/sys/arm64/arm64/psci.c
+++ b/sys/arm64/arm64/psci.c
@@ -1,0 +1,293 @@
+/*-
+ * Copyright (c) 2014 Robin Randhawa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/*
+ * This implements support for ARM's Power State Co-ordination Interface
+ * [PSCI]. The implementation adheres to version 0.2 of the PSCI specification
+ * but also supports v0.1. PSCI standardizes operations such as system reset, CPU
+ * on/off/suspend. PSCI requires a compliant firmware implementation.
+ *
+ * The PSCI specification used for this implementation is available at:
+ *
+ * <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0022b/index.html>.
+ *
+ * TODO:
+ * 1. Add support for AAarch32 callers [this implementation assumes only
+ *    AArch64 callers].
+ * 3. Add support for remaining PSCI calls [this implementation only
+ *    supports get_version, system_reset and cpu_on].
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/bus.h>
+#include <sys/eventhandler.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/reboot.h>
+
+#include <machine/bus.h>
+#include <machine/psci.h>
+
+#include <dev/fdt/fdt_common.h>
+#include <dev/ofw/openfirm.h>
+#include <dev/ofw/ofw_bus.h>
+#include <dev/ofw/ofw_bus_subr.h>
+
+#ifdef	DEBUG
+#define	dprintf(fmt, args...) printf(fmt, ##args)
+#else
+#define	dprintf(fmt, args...)
+#endif
+
+struct psci_softc {
+	device_t        dev;
+
+	psci_callfn_t	psci_call;
+	uint32_t	psci_fnids[PSCI_FN_MAX];
+};
+
+static int psci_v0_1_init(device_t dev);
+static int psci_v0_2_init(device_t dev);
+
+struct psci_softc *psci_softc = NULL;
+
+static struct ofw_compat_data compat_data[] = {
+	{"arm,psci-0.2",        (uintptr_t)psci_v0_2_init},
+	{"arm,psci",            (uintptr_t)psci_v0_1_init},
+	{NULL,                  0}
+};
+
+static int psci_probe(device_t dev);
+static int psci_attach(device_t dev);
+static void psci_shutdown(void *, int);
+
+static device_method_t psci_methods[] = {
+	DEVMETHOD(device_probe,     psci_probe),
+	DEVMETHOD(device_attach,    psci_attach),
+
+	DEVMETHOD_END
+};
+
+static driver_t psci_driver = {
+	"psci",
+	psci_methods,
+	sizeof(struct psci_softc),
+};
+
+static devclass_t psci_devclass;
+
+EARLY_DRIVER_MODULE(psci, simplebus, psci_driver, psci_devclass, 0, 0,
+    BUS_PASS_CPU + BUS_PASS_ORDER_FIRST);
+EARLY_DRIVER_MODULE(psci, ofwbus, psci_driver, psci_devclass, 0, 0,
+    BUS_PASS_CPU + BUS_PASS_ORDER_FIRST);
+
+static int
+psci_probe(device_t dev)
+{
+	const struct ofw_compat_data *ocd;
+
+	if (!ofw_bus_status_okay(dev))
+		return (ENXIO);
+
+	ocd = ofw_bus_search_compatible(dev, compat_data);
+	if (ocd->ocd_str == NULL)
+		return (ENXIO);
+
+	device_set_desc(dev, "ARM Power State Co-ordination Interface Driver");
+
+	return (BUS_PROBE_SPECIFIC);
+}
+
+static int
+psci_attach(device_t dev)
+{
+	struct psci_softc *sc = device_get_softc(dev);
+	const struct ofw_compat_data *ocd;
+	psci_initfn_t psci_init;
+	phandle_t node;
+	char method[16];
+
+	if (psci_softc != NULL)
+		return (ENXIO);
+
+	ocd = ofw_bus_search_compatible(dev, compat_data);
+	psci_init = (psci_initfn_t)ocd->ocd_data;
+	KASSERT(psci_init != NULL, ("PSCI init function cannot be NULL"));
+
+	node = ofw_bus_get_node(dev);
+	if ((OF_getprop(node, "method", method, sizeof(method))) > 0) {
+		if (strcmp(method, "hvc") == 0)
+			sc->psci_call = psci_hvc_despatch;
+		else if (strcmp(method, "smc") == 0)
+			sc->psci_call = psci_smc_despatch;
+		else {
+			device_printf(dev,
+			   "psci_attach: PSCI conduit \"%s\" invalid\n",
+			    method);
+			return (ENXIO);
+		}
+	} else {
+		device_printf(dev,
+		    "psci_attach: PSCI conduit not supplied in the DT\n");
+		return (ENXIO);
+	}
+
+	if (psci_init(dev))
+		return (ENXIO);
+
+	psci_softc = sc;
+
+	return (0);
+}
+
+static int
+psci_get_version(struct psci_softc *sc)
+{
+	uint32_t fnid;
+
+	/* PSCI version wasn't supported in v0.1. */
+	fnid = sc->psci_fnids[PSCI_FN_VERSION];
+	if (fnid)
+		return (sc->psci_call(fnid, 0, 0, 0));
+
+	return (PSCI_RETVAL_NOT_SUPPORTED);
+}
+
+int
+psci_cpu_on(unsigned long cpu, unsigned long entry, unsigned long context_id)
+{
+
+	/* PSCI v0.1 and v0.2 both support cpu_on. */
+	return(psci_softc->psci_call(psci_softc->psci_fnids[PSCI_FN_CPU_ON], cpu,
+	    entry, context_id));
+}
+
+static void
+psci_shutdown(void *xsc, int howto)
+{
+	uint32_t fn = 0;
+
+	/* PSCI system_off and system_reset werent't supported in v0.1. */
+	if ((howto & RB_POWEROFF) != 0)
+		fn = psci_softc->psci_fnids[PSCI_FN_SYSTEM_OFF];
+	else if ((howto & RB_HALT) == 0)
+		fn = psci_softc->psci_fnids[PSCI_FN_SYSTEM_RESET];
+
+	if (fn)
+		psci_softc->psci_call(fn, 0, 0, 0);
+
+	/* System reset and off do not return. */
+}
+
+static int
+psci_v0_1_init(device_t dev)
+{
+	struct psci_softc *sc = device_get_softc(dev);
+	int psci_fn;
+	uint32_t psci_fnid;
+	phandle_t node;
+	int len;
+
+
+	/* Zero out the function ID table - Is this needed ? */
+	for (psci_fn = PSCI_FN_VERSION, psci_fnid = PSCI_FNID_VERSION;
+	    psci_fn < PSCI_FN_MAX; psci_fn++, psci_fnid++)
+		sc->psci_fnids[psci_fn] = 0;
+
+	/* PSCI v0.1 doesn't specify function IDs. Get them from DT */
+	node = ofw_bus_get_node(dev);
+
+	if ((len = OF_getproplen(node, "cpu_suspend"))) {
+		OF_getencprop(node, "cpu_suspend", &psci_fnid, len);
+		sc->psci_fnids[PSCI_FN_CPU_SUSPEND] = psci_fnid;
+	}
+
+	if ((len = OF_getproplen(node, "cpu_on"))) {
+		OF_getencprop(node, "cpu_on", &psci_fnid, len);
+		sc->psci_fnids[PSCI_FN_CPU_ON] = psci_fnid;
+	}
+
+	if ((len = OF_getproplen(node, "cpu_off"))) {
+		OF_getencprop(node, "cpu_off", &psci_fnid, len);
+		sc->psci_fnids[PSCI_FN_CPU_OFF] = psci_fnid;
+	}
+
+	if ((len = OF_getproplen(node, "migrate"))) {
+		OF_getencprop(node, "migrate", &psci_fnid, len);
+		sc->psci_fnids[PSCI_FN_MIGRATE] = psci_fnid;
+	}
+
+	if (bootverbose)
+		device_printf(dev, "PSCI version 0.1 available\n");
+
+	return(0);
+}
+
+static int
+psci_v0_2_init(device_t dev)
+{
+	struct psci_softc *sc = device_get_softc(dev);
+	int version;
+
+	/* PSCI v0.2 specifies explicit function IDs. */
+	sc->psci_fnids[PSCI_FN_VERSION]		    = PSCI_FNID_VERSION;
+	sc->psci_fnids[PSCI_FN_CPU_SUSPEND]	    = PSCI_FNID_CPU_SUSPEND;
+	sc->psci_fnids[PSCI_FN_CPU_OFF]		    = PSCI_FNID_CPU_OFF;
+	sc->psci_fnids[PSCI_FN_CPU_ON]		    = PSCI_FNID_CPU_ON;
+	sc->psci_fnids[PSCI_FN_AFFINITY_INFO]	    = PSCI_FNID_AFFINITY_INFO;
+	sc->psci_fnids[PSCI_FN_MIGRATE]		    = PSCI_FNID_MIGRATE;
+	sc->psci_fnids[PSCI_FN_MIGRATE_INFO_TYPE]   = PSCI_FNID_MIGRATE_INFO_TYPE;
+	sc->psci_fnids[PSCI_FN_MIGRATE_INFO_UP_CPU] = PSCI_FNID_MIGRATE_INFO_UP_CPU;
+	sc->psci_fnids[PSCI_FN_SYSTEM_OFF]	    = PSCI_FNID_SYSTEM_OFF;
+	sc->psci_fnids[PSCI_FN_SYSTEM_RESET]	    = PSCI_FNID_SYSTEM_RESET;
+
+	version = psci_get_version(sc);
+
+	if (version == PSCI_RETVAL_NOT_SUPPORTED)
+		return (1);
+
+	if ((PSCI_VER_MAJOR(version) != 0) && (PSCI_VER_MINOR(version) != 2)) {
+		device_printf(dev, "PSCI version number mismatched with DT\n");
+		return (1);
+	}
+
+	if (bootverbose)
+		device_printf(dev, "PSCI version 0.2 available\n");
+
+	/*
+	 * We only register this for v0.2 since v0.1 doesn't support
+	 * system_reset.
+	 */
+	EVENTHANDLER_REGISTER(shutdown_final, psci_shutdown, sc,
+	    SHUTDOWN_PRI_LAST);
+
+	return (0);
+}

--- a/sys/arm64/arm64/swtch.S
+++ b/sys/arm64/arm64/swtch.S
@@ -35,8 +35,21 @@
 
 __FBSDID("$FreeBSD$");
 
+#define MPIDR_CPU_MSK	    0xff
+
+#define GET_PCPU(tmp, tmp2) \
+	mrs	tmp, mpidr_el1;		    \
+	and	tmp, tmp, #MPIDR_CPU_MSK;   \
+	adr	tmp2, .Lcurpcpusz;	    \
+	ldr	tmp2, [tmp2];		    \
+	mul	tmp, tmp, tmp2;		    \
+	adr	tmp2, .Lcurpcpu;	    \
+	ldr	tmp2, [tmp2];		    \
+	add	tmp, tmp, tmp2
+
 .Lcurpcpu:
 	.quad	_C_LABEL(__pcpu)
+.Lcurpcpusz:
 	.quad	PCPU_SIZE
 
 /*
@@ -44,7 +57,9 @@ __FBSDID("$FreeBSD$");
  */
 ENTRY(cpu_throw)
 #ifdef SMP
+#if 0
 #error cpu_throw needs to be ported to support SMP
+#endif
 #endif
 
 #ifdef VFP
@@ -55,8 +70,7 @@ ENTRY(cpu_throw)
 #endif
 
 	/* Load the PCPU area */
-	/* TODO: Adjust for the core we are on */
-	ldr	x3, .Lcurpcpu
+	GET_PCPU(x3, x4)
 
 	/* Store the new curthread */
 	str	x1, [x3, #PC_CURTHREAD]
@@ -110,12 +124,13 @@ END(cpu_throw)
  */
 ENTRY(cpu_switch)
 #ifdef SMP
+#if 0
 #error cpu_switch needs to be ported to support SMP
+#endif
 #endif
 
 	/* Load the PCPU area */
-	/* TODO: Adjust for the core we are on */
-	ldr	x3, .Lcurpcpu
+	GET_PCPU(x3, x4)
 
 	/* Store the new curthread */
 	str	x1, [x3, #PC_CURTHREAD]
@@ -181,7 +196,9 @@ ENTRY(cpu_switch)
 	/* Release the old thread */
 	str	x2, [x0, #TD_LOCK]
 #if defined(SCHED_ULE) && defined(SMP)
+#if 0
 #error We may need to wait for the lock here
+#endif
 #endif
 
 	/* Restore the registers */

--- a/sys/arm64/conf/GENERIC
+++ b/sys/arm64/conf/GENERIC
@@ -108,3 +108,6 @@ device		bpf		# Berkeley packet filter
 
 device		psci		# Support for ARM PSCI
 options 	FDT
+options 	SMP			# Enable multiple cores
+options 	IPI_IRQ_START=0
+options 	IPI_IRQ_END=15

--- a/sys/arm64/conf/GENERIC
+++ b/sys/arm64/conf/GENERIC
@@ -106,4 +106,5 @@ device		firmware	# firmware assist module
 # Note that 'bpf' is required for DHCP.
 device		bpf		# Berkeley packet filter
 
+device		psci		# Support for ARM PSCI
 options 	FDT

--- a/sys/arm64/include/cpufunc.h
+++ b/sys/arm64/include/cpufunc.h
@@ -88,5 +88,267 @@ get_mpidr(void)
 	return (mpidr);
 }
 
+struct cpu_functions {
+
+	/* CPU functions */
+
+	u_int	(*cf_id)		(void);
+	void	(*cf_cpwait)		(void);
+
+	/* MMU functions */
+
+	u_int	(*cf_control)		(u_int bic, u_int eor);
+	void	(*cf_setttb)		(u_int ttb);
+	u_int	(*cf_faultstatus)	(void);
+	u_int	(*cf_faultaddress)	(void);
+
+	/* TLB functions */
+
+	void	(*cf_tlb_flushID)	(void);
+	void	(*cf_tlb_flushID_SE)	(u_int va);
+	void	(*cf_tlb_flushI)	(void);
+	void	(*cf_tlb_flushI_SE)	(u_int va);
+	void	(*cf_tlb_flushD)	(void);
+	void	(*cf_tlb_flushD_SE)	(u_int va);
+
+	/*
+	 * Cache operations:
+	 *
+	 * We define the following primitives:
+	 *
+	 *	icache_sync_all		Synchronize I-cache
+	 *	icache_sync_range	Synchronize I-cache range
+	 *
+	 *      FIXME: Not implementing this for the moment. Do we need to ?
+	 *	dcache_wbinv_all	Write-back and Invalidate D-cache
+	 *	dcache_wbinv_range	Write-back and Invalidate D-cache range
+	 *	dcache_inv_range	Invalidate D-cache range
+	 *	dcache_wb_range		Write-back D-cache range
+	 *
+	 *      FIXME: Not implementing this for the moment. Do we need to ?
+	 *	idcache_wbinv_all	Write-back and Invalidate D-cache,
+	 *				Invalidate I-cache
+	 *	idcache_wbinv_range	Write-back and Invalidate D-cache,
+	 *				Invalidate I-cache range
+	 *
+	 * Note that the ARM term for "write-back" is "clean".  We use
+	 * the term "write-back" since it's a more common way to describe
+	 * the operation.
+	 *
+	 * There are some rules that must be followed:
+	 *
+	 *	ID-cache Invalidate All:
+	 *		Unlike other functions, this one must never write back.
+	 *		It is used to intialize the MMU when it is in an unknown
+	 *		state (such as when it may have lines tagged as valid
+	 *		that belong to a previous set of mappings).
+	 * 
+	 *	I-cache Synch (all or range):
+	 *		The goal is to synchronize the instruction stream,
+	 *		so you may beed to write-back dirty D-cache blocks
+	 *		first.  If a range is requested, and you can't
+	 *		synchronize just a range, you have to hit the whole
+	 *		thing.
+	 *
+	 *	D-cache Write-Back and Invalidate range:
+	 *		If you can't WB-Inv a range, you must WB-Inv the
+	 *		entire D-cache.
+	 *
+	 *	D-cache Invalidate:
+	 *		If you can't Inv the D-cache, you must Write-Back
+	 *		and Invalidate.  Code that uses this operation
+	 *		MUST NOT assume that the D-cache will not be written
+	 *		back to memory.
+	 *
+	 *	D-cache Write-Back:
+	 *		If you can't Write-back without doing an Inv,
+	 *		that's fine.  Then treat this as a WB-Inv.
+	 *		Skipping the invalidate is merely an optimization.
+	 *
+	 *	All operations:
+	 *		Valid virtual addresses must be passed to each
+	 *		cache operation.
+	 */
+	void	(*cf_icache_sync_range)	(vm_offset_t, vm_size_t);
+
+	void	(*cf_dcache_wbinv_range) (vm_offset_t, vm_size_t);
+	void	(*cf_dcache_inv_range)	(vm_offset_t, vm_size_t);
+	void	(*cf_dcache_wb_range)	(vm_offset_t, vm_size_t);
+
+	void	(*cf_idcache_wbinv_range) (vm_offset_t, vm_size_t);
+
+	void	(*cf_l2cache_wbinv_range)	  (vm_offset_t, vm_size_t);
+	void	(*cf_l2cache_inv_range)	  (vm_offset_t, vm_size_t);
+	void	(*cf_l2cache_wb_range)	  (vm_offset_t, vm_size_t);
+	void	(*cf_l2cache_drain_writebuf)	  (void);
+
+	/* Other functions */
+
+	void	(*cf_flush_prefetchbuf)	(void);
+	void	(*cf_drain_writebuf)	(void);
+	void	(*cf_flush_brnchtgt_C)	(void);
+	void	(*cf_flush_brnchtgt_E)	(u_int va);
+
+	void	(*cf_sleep)		(int mode);
+
+	/* Soft functions */
+
+	int	(*cf_dataabt_fixup)	(void *arg);
+	int	(*cf_prefetchabt_fixup)	(void *arg);
+
+	void	(*cf_context_switch)	(void);
+
+	void	(*cf_setup)		(char *string);
+};
+
+extern struct cpu_functions cpufuncs;
+extern u_int cputype;
+
+#define cpu_id()		cpufuncs.cf_id()
+#define	cpu_cpwait()		cpufuncs.cf_cpwait()
+
+#define cpu_control(c, e)	cpufuncs.cf_control(c, e)
+#define cpu_setttb(t)		cpufuncs.cf_setttb(t)
+#define cpu_faultstatus()	cpufuncs.cf_faultstatus()
+#define cpu_faultaddress()	cpufuncs.cf_faultaddress()
+
+#ifndef SMP
+
+#define	cpu_tlb_flushID()	cpufuncs.cf_tlb_flushID()
+#define	cpu_tlb_flushID_SE(e)	cpufuncs.cf_tlb_flushID_SE(e)
+#define	cpu_tlb_flushI()	cpufuncs.cf_tlb_flushI()
+#define	cpu_tlb_flushI_SE(e)	cpufuncs.cf_tlb_flushI_SE(e)
+#define	cpu_tlb_flushD()	cpufuncs.cf_tlb_flushD()
+#define	cpu_tlb_flushD_SE(e)	cpufuncs.cf_tlb_flushD_SE(e)
+
+#else
+void tlb_broadcast(int);
+
+#if defined(CPU_CORTEXA)
+#define TLB_BROADCAST	/* No need to explicitely send an IPI */
+#else
+#define TLB_BROADCAST	tlb_broadcast(7)
+#endif
+
+#define	cpu_tlb_flushID() do { \
+	cpufuncs.cf_tlb_flushID(); \
+	TLB_BROADCAST; \
+} while(0)
+
+#define	cpu_tlb_flushID_SE(e) do { \
+	cpufuncs.cf_tlb_flushID_SE(e); \
+	TLB_BROADCAST; \
+} while(0)
+
+
+#define	cpu_tlb_flushI() do { \
+	cpufuncs.cf_tlb_flushI(); \
+	TLB_BROADCAST; \
+} while(0)
+
+
+#define	cpu_tlb_flushI_SE(e) do { \
+	cpufuncs.cf_tlb_flushI_SE(e); \
+	TLB_BROADCAST; \
+} while(0)
+
+
+#define	cpu_tlb_flushD() do { \
+	cpufuncs.cf_tlb_flushD(); \
+	TLB_BROADCAST; \
+} while(0)
+
+
+#define	cpu_tlb_flushD_SE(e) do { \
+	cpufuncs.cf_tlb_flushD_SE(e); \
+	TLB_BROADCAST; \
+} while(0)
+
+#endif
+
+#define	cpu_icache_sync_range(a, s) cpufuncs.cf_icache_sync_range((a), (s))
+
+#define	cpu_dcache_wbinv_range(a, s) cpufuncs.cf_dcache_wbinv_range((a), (s))
+#define	cpu_dcache_inv_range(a, s) cpufuncs.cf_dcache_inv_range((a), (s))
+#define	cpu_dcache_wb_range(a, s) cpufuncs.cf_dcache_wb_range((a), (s))
+
+#define	cpu_idcache_wbinv_range(a, s) cpufuncs.cf_idcache_wbinv_range((a), (s))
+#define cpu_l2cache_wb_range(a, s) cpufuncs.cf_l2cache_wb_range((a), (s))
+#define cpu_l2cache_inv_range(a, s) cpufuncs.cf_l2cache_inv_range((a), (s))
+#define cpu_l2cache_wbinv_range(a, s) cpufuncs.cf_l2cache_wbinv_range((a), (s))
+#define cpu_l2cache_drain_writebuf() cpufuncs.cf_l2cache_drain_writebuf()
+
+#define	cpu_flush_prefetchbuf()	cpufuncs.cf_flush_prefetchbuf()
+#define	cpu_drain_writebuf()	cpufuncs.cf_drain_writebuf()
+#define	cpu_flush_brnchtgt_C()	cpufuncs.cf_flush_brnchtgt_C()
+#define	cpu_flush_brnchtgt_E(e)	cpufuncs.cf_flush_brnchtgt_E(e)
+
+#define cpu_sleep(m)		cpufuncs.cf_sleep(m)
+
+#define cpu_dataabt_fixup(a)		cpufuncs.cf_dataabt_fixup(a)
+#define cpu_prefetchabt_fixup(a)	cpufuncs.cf_prefetchabt_fixup(a)
+#define ABORT_FIXUP_OK		0	/* fixup succeeded */
+#define ABORT_FIXUP_FAILED	1	/* fixup failed */
+#define ABORT_FIXUP_RETURN	2	/* abort handler should return */
+
+#define cpu_setup(a)			cpufuncs.cf_setup(a)
+
+int	set_cpufuncs		(void);
+#define ARCHITECTURE_NOT_PRESENT	1	/* known but not configured */
+#define ARCHITECTURE_NOT_SUPPORTED	2	/* not known */
+
+void	arm64_nullop		(void);
+int	arm64_null_fixup	(void *);
+int	early_abort_fixup	(void *);
+int	late_abort_fixup	(void *);
+u_int	arm64_id		(void);
+u_int	arm64_cpuid		(void);
+u_int	arm64_control		(u_int clear, u_int bic);
+u_int	arm64_faultstatus	(void);
+u_int	arm64_faultaddress	(void);
+u_int	cpu_pfr			(int);
+
+#define setttb		cpu_setttb
+#define drain_writebuf	cpu_drain_writebuf
+
+void	arm64_setttb			(u_int);
+void	arm64_tlb_flushID		(void);
+void	arm64_tlb_flushID_SE		(u_int);
+void	arm64_icache_sync_range		(vm_offset_t, vm_size_t);
+void	arm64_idcache_wbinv_range	(vm_offset_t, vm_size_t);
+void	arm64_dcache_wbinv_range	(vm_offset_t, vm_size_t);
+void	arm64_dcache_inv_range		(vm_offset_t, vm_size_t);
+void	arm64_dcache_wb_range		(vm_offset_t, vm_size_t);
+void	arm64_cpu_sleep			(int);
+void	arm64_setup			(char *string);
+void	arm64_context_switch		(void);
+void	arm64_drain_writebuf		(void);
+void	arm64_sev			(void);
+void	arm64_sleep			(int unused);
+u_int	arm64_auxctrl			(u_int, u_int);
+
+/*
+ * Cache info variables.
+ */
+
+/* PRIMARY CACHE VARIABLES */
+extern int	arm64_picache_size;
+extern int	arm64_picache_line_size;
+extern int	arm64_picache_ways;
+
+extern int	arm64_pdcache_size;	/* and unified */
+extern int	arm64_pdcache_line_size;
+extern int	arm64_pdcache_ways;
+
+extern int	arm64_pcache_type;
+extern int	arm64_pcache_unified;
+
+extern int	arm64_dcache_align;
+extern int	arm64_dcache_align_mask;
+
+extern u_int	arm64_cache_level;
+extern u_int	arm64_cache_loc;
+extern u_int	arm64_cache_type[14];
+
 #endif	/* _KERNEL */
 #endif	/* _MACHINE_CPUFUNC_H_ */

--- a/sys/arm64/include/intr.h
+++ b/sys/arm64/include/intr.h
@@ -33,11 +33,19 @@ int	arm_config_intr(u_int, enum intr_trigger, enum intr_polarity);
 void	arm_cpu_intr(struct trapframe *);
 void	arm_dispatch_intr(u_int, struct trapframe *);
 int	arm_enable_intr(void);
-void	arm_mask_irq(u_int);
+int	arm_get_next_irq(int);
+void	arm_mask_irq(uintptr_t);
 void	arm_register_pic(device_t, u_int);
 int	arm_setup_intr(const char *, driver_filter_t *, driver_intr_t,
 				void *, u_int, enum intr_type, void **);
 int	arm_teardown_intr(void *);
-void	arm_unmask_irq(u_int);
+void	arm_unmask_irq(uintptr_t);
 
+void arm_irq_memory_barrier(uintptr_t);
+
+void arm_init_secondary_ic(void);
+void arm_irq_memory_barrier(uintptr_t);
+
+int  gic_decode_fdt(uint32_t iparentnode, uint32_t *intrcells, int *interrupt,
+    int *trig, int *pol);
 #endif	/* _MACHINE_INTR_H */

--- a/sys/arm64/include/pcpu.h
+++ b/sys/arm64/include/pcpu.h
@@ -36,7 +36,9 @@
 #define	ALT_STACK_SIZE	128
 
 #define	PCPU_MD_FIELDS							\
-	char __pad[129]
+	unsigned int pc_cpu;						\
+	struct pmap *pc_curpmap;					\
+	char __pad[113]
 
 #ifdef _KERNEL
 

--- a/sys/arm64/include/pmap.h
+++ b/sys/arm64/include/pmap.h
@@ -51,6 +51,7 @@
 #ifndef LOCORE
 
 #include <sys/queue.h>
+#include <sys/_cpuset.h>
 #include <sys/_lock.h>
 #include <sys/_mutex.h>
 
@@ -89,6 +90,8 @@ struct pmap {
 	struct mtx		pm_mtx;
 	struct pmap_statistics	pm_stats;	/* pmap statictics */
 	pd_entry_t		*pm_l1;
+	cpuset_t		pm_active;	/* active on cpus */
+	cpuset_t		pm_save;	/* Context valid on cpus mask */
 	TAILQ_HEAD(,pv_chunk)	pm_pvchunk;	/* list of mappings in pmap */
 };
 

--- a/sys/arm64/include/psci.h
+++ b/sys/arm64/include/psci.h
@@ -1,0 +1,123 @@
+/*-
+ * Copyright (c) 2013, 2014 Robin Randhawa
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	_MACHINE_PSCI_H_
+#define	_MACHINE_PSCI_H_
+
+#include <sys/types.h>
+
+typedef int (*psci_initfn_t)(device_t dev);
+typedef int (*psci_callfn_t)(uint64_t, uint64_t, uint64_t, uint64_t);
+
+extern int psci_present;
+
+void	psci_system_reset(void);
+int	psci_cpu_on(unsigned long cpu, unsigned long entry, unsigned long context_id);
+
+/*
+ * PSCI return codes.
+ */
+#define	PSCI_RETVAL_SUCCESS		0
+#define	PSCI_RETVAL_NOT_SUPPORTED	-1
+#define	PSCI_RETVAL_INVALID_PARAMS	-2
+#define	PSCI_RETVAL_DENIED		-3
+#define	PSCI_RETVAL_ALREADY_ON		-4
+#define	PSCI_RETVAL_ON_PENDING		-5
+#define	PSCI_RETVAL_INTERNAL_FAILURE	-6
+#define	PSCI_RETVAL_NOT_PRESENT		-7
+#define	PSCI_RETVAL_DISABLED		-8
+
+/*
+ * PSCI function codes (as per PSCI v0.2).
+ *
+ * These assume that PSCI function calls are always made from AARCH64 context.
+ *
+ */
+#define	PSCI_FNID_VERSION		0x84000000
+#define	PSCI_FNID_CPU_SUSPEND		0xc4000001
+#define	PSCI_FNID_CPU_OFF		0x84000002
+#define	PSCI_FNID_CPU_ON		0xc4000003
+#define	PSCI_FNID_AFFINITY_INFO		0xc4000004
+#define	PSCI_FNID_MIGRATE		0xc4000005
+#define	PSCI_FNID_MIGRATE_INFO_TYPE	0x84000006
+#define	PSCI_FNID_MIGRATE_INFO_UP_CPU	0xc4000007
+#define	PSCI_FNID_SYSTEM_OFF		0x84000008
+#define	PSCI_FNID_SYSTEM_RESET		0x84000009
+
+#define	PSCI_VER_MAJOR(v)		((v >> 16) & 0xFF)
+#define	PSCI_VER_MINOR(v)		(v & 0xFF)
+
+enum psci_fn {
+	PSCI_FN_VERSION,
+	PSCI_FN_CPU_SUSPEND,
+	PSCI_FN_CPU_OFF,
+	PSCI_FN_CPU_ON,
+	PSCI_FN_AFFINITY_INFO,
+	PSCI_FN_MIGRATE,
+	PSCI_FN_MIGRATE_INFO_TYPE,
+	PSCI_FN_MIGRATE_INFO_UP_CPU,
+	PSCI_FN_SYSTEM_OFF,
+	PSCI_FN_SYSTEM_RESET,
+	PSCI_FN_MAX
+};
+
+static __inline int
+psci_hvc_despatch(uint64_t psci_fnid, uint64_t arg0, uint64_t arg1, uint64_t arg2)
+{
+	__asm __volatile(
+	    "mov    x0, %0     \n"
+	    "mov    x1, %1     \n"
+	    "mov    x2, %2     \n"
+	    "mov    x3, %3     \n"
+	    "hvc #0             \n"
+	    : "+r" (psci_fnid)
+	    : "r" (arg0), "r" (arg1), "r" (arg2)
+	    : "x0", "x1", "x2", "x3"
+	    );
+
+	return psci_fnid;
+}
+
+static __inline int
+psci_smc_despatch(uint64_t psci_fnid, uint64_t arg0, uint64_t arg1, uint64_t arg2)
+{
+	__asm __volatile(
+	    "mov    x0, %0     \n"
+	    "mov    x1, %1     \n"
+	    "mov    x2, %2     \n"
+	    "mov    x3, %3     \n"
+	    "smc #0             \n"
+	    : "+r" (psci_fnid)
+	    : "r" (arg0), "r" (arg1), "r" (arg2)
+	    : "x0", "x1", "x2", "x3"
+	    );
+
+	return psci_fnid;
+}
+
+#endif /* _MACHINE_PSCI_H_ */

--- a/sys/arm64/include/smp.h
+++ b/sys/arm64/include/smp.h
@@ -29,4 +29,37 @@
 #ifndef	_MACHINE_SMP_H_
 #define	_MACHINE_SMP_H_
 
+#include <sys/_cpuset.h>
+#include <machine/pcb.h>
+
+#define IPI_AST		0
+#define IPI_PREEMPT	2
+#define IPI_RENDEZVOUS	3
+#define IPI_STOP	4
+#define IPI_STOP_HARD	4
+#define IPI_HARDCLOCK	6
+#define IPI_TLB		7
+
+void	init_secondary(int cpu);
+void	mpentry(void);
+
+void	ipi_all_but_self(u_int ipi);
+void	ipi_cpu(int cpu, u_int ipi);
+void	ipi_selected(cpuset_t cpus, u_int ipi);
+
+/* PIC interface */
+void	pic_ipi_send(cpuset_t cpus, u_int ipi);
+void	pic_ipi_clear(int ipi);
+int	pic_ipi_read(int arg);
+
+/* Platform interface */
+void	platform_mp_setmaxid(void);
+int	platform_mp_probe(void);
+void	platform_mp_start_ap(void);
+void	platform_mp_init_secondary(void);
+
+void	platform_ipi_send(cpuset_t cpus, u_int ipi);
+
+/* global data in mp_machdep.c */
+extern struct pcb               stoppcbs[];
 #endif /* !_MACHINE_SMP_H_ */

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -26,6 +26,7 @@ arm64/arm64/minidump_machdep.c	standard
 arm64/arm64/nexus.c		standard
 arm64/arm64/pic_if.m		standard
 arm64/arm64/pmap.c		standard
+arm64/arm64/psci.c		optional	psci
 arm64/arm64/stack_machdep.c	standard
 arm64/arm64/support.c		standard
 arm64/arm64/support_asm.S	standard

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -27,6 +27,7 @@ arm64/arm64/nexus.c		standard
 arm64/arm64/pic_if.m		standard
 arm64/arm64/pmap.c		standard
 arm64/arm64/psci.c		optional	psci
+arm64/arm64/mp_machdep.c	optional	smp
 arm64/arm64/stack_machdep.c	standard
 arm64/arm64/support.c		standard
 arm64/arm64/support_asm.S	standard

--- a/sys/conf/files.arm64
+++ b/sys/conf/files.arm64
@@ -10,6 +10,8 @@ arm64/arm64/busdma_machdep.c	standard
 arm64/arm64/clock.c		standard
 arm64/arm64/copyinout.S		standard
 arm64/arm64/copystr.c		standard
+arm64/arm64/cpufunc.c		standard
+arm64/arm64/cpufunc_asm.S	standard
 arm64/arm64/dump_machdep.c	standard
 arm64/arm64/elf_machdep.c	standard
 arm64/arm64/exception.S		standard

--- a/sys/conf/options.arm64
+++ b/sys/conf/options.arm64
@@ -1,2 +1,4 @@
 ARM64		opt_global.h
 VFP		opt_global.h
+IPI_IRQ_START		opt_smp.h
+IPI_IRQ_END		opt_smp.h


### PR DESCRIPTION
Hi Andrew.

I've fixed up two of these patches as per your previous comments (A57 ID and the PSCI driver). Please have a look. The PSCI driver now includes support PSCI v0.1. Tested with Qemu.

As discussed with you last Sunday, I've also included my work-in-progress attempt at getting basic SMP support going with qemu. Secondary CPUs come up using PSCI and they seem to receive and service interrupts. Tested using qemu's GDB stub. This is unstable - with user land, I see unexpected exceptions causing panics and eventually reboots. All the same, hopefully this helps with getting the basic structure in shape for SMP.

I've also introduced a cpufunc implementation modelled on the ARMv7 implementation as a way to express CPU control, TLB and cache manipulation. This needs proving, ideally with the architectural model and DS5.
